### PR TITLE
パスワード再設定画面の作成 #10

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,10 @@
+class PasswordResetsController < ApplicationController
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,8 +1,8 @@
 class UserSessionsController < ApplicationController
   def new; end
+
   def create
     @user = login(params[:email], params[:password])
-
     if @user
       redirect_back_or_to(:users, notice: 'Login successful')
     else

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,13 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.reset_password_email.subject
+  #
+  def reset_password_email
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,8 +6,8 @@ class UserMailer < ApplicationMailer
   #   en.user_mailer.reset_password_email.subject
   #
   def reset_password_email
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+    @user = User.find(user.id)
+    @url  = edit_password_reset_url(@user.reset_password_token)
+    mail(to: user.email, subject: 'パスワードリセット')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :reset_password_token, uniqueness: true, allow_nil: true
 
   validates :email, uniqueness: true
 end

--- a/app/views/password_resets/create.html.erb
+++ b/app/views/password_resets/create.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#create</h1>
+<p>Find me in app/views/password_resets/create.html.erb</p>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#edit</h1>
+<p>Find me in app/views/password_resets/edit.html.erb</p>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,16 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1>パスワード再設定</h1>
+        <%= form_with url: password_resets_path, local: true do |f| %>
+          <div class="form-group">
+            <%= f.label :メールアドレス %>
+            <%= f.text_field :email, class: 'form-control' %>
+          </div>
+          <div class="actions">
+            <%= f.submit '送信', class: 'btn btn-primary' %>
+          </div>
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/update.html.erb
+++ b/app/views/password_resets/update.html.erb
@@ -1,0 +1,2 @@
+<h1>PasswordResets#update</h1>
+<p>Find me in app/views/password_resets/update.html.erb</p>

--- a/app/views/user_mailer/reset_password_email.html.erb
+++ b/app/views/user_mailer/reset_password_email.html.erb
@@ -1,0 +1,5 @@
+<h1>User#reset_password_email</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/reset_password_email.html.erb
+</p>

--- a/app/views/user_mailer/reset_password_email.text.erb
+++ b/app/views/user_mailer/reset_password_email.text.erb
@@ -1,0 +1,3 @@
+User#reset_password_email
+
+<%= @greeting %>, find me in app/views/user_mailer/reset_password_email.text.erb

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -14,5 +14,5 @@
   <%= f.submit '登録', class: 'btn btn-primary' %>
 <% end %>
 <div class='text-center'>
-  <%= link_to 'すでに登録が済みの方はこちら', login_path %>
+  <%= link_to 'すでに登録がお済みの方はこちら', login_path %>
 </div>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = []
+Rails.application.config.sorcery.submodules = [:reset_password]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -392,7 +392,7 @@ Rails.application.config.sorcery.configure do |config|
     # Password reset mailer class.
     # Default: `nil`
     #
-    # user.reset_password_mailer =
+    user.reset_password_mailer = User.Mailer
 
     # Reset password email method on your mailer class.
     # Default: `:reset_password_email`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
   resources :users
   resources :boards
+  resources :password_resets, only: %i[new create edit update]
 end

--- a/db/migrate/20211029192111_sorcery_reset_password.rb
+++ b/db/migrate/20211029192111_sorcery_reset_password.rb
@@ -1,0 +1,10 @@
+class SorceryResetPassword < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :reset_password_token, :string, default: nil
+    add_column :users, :reset_password_token_expires_at, :datetime, default: nil
+    add_column :users, :reset_password_email_sent_at, :datetime, default: nil
+    add_column :users, :access_count_to_reset_password_page, :integer, default: 0
+
+    add_index :users, :reset_password_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_29_013552) do
+ActiveRecord::Schema.define(version: 2021_10_29_192111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,12 @@ ActiveRecord::Schema.define(version: 2021_10_29_013552) do
     t.text "reason"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_token_expires_at"
+    t.datetime "reset_password_email_sent_at"
+    t.integer "access_count_to_reset_password_page", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
   add_foreign_key "boards", "users"

--- a/spec/fixtures/user_mailer/reset_password_email
+++ b/spec/fixtures/user_mailer/reset_password_email
@@ -1,0 +1,3 @@
+UserMailer#reset_password_email
+
+Hi, find me in app/views/user_mailer/reset_password_email

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/reset_password_email
+  def reset_password_email
+    UserMailer.reset_password_email
+  end
+
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe UserMailer, type: :mailer do
+  describe "reset_password_email" do
+    let(:mail) { UserMailer.reset_password_email }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Reset password email")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Hi")
+    end
+  end
+
+end


### PR DESCRIPTION
## 概要
close #10

追加した機能
パスワード再設定画面を作成し設定も行いました。
画像
![image](https://user-images.githubusercontent.com/75526672/139542760-214d050d-88e1-4a72-b97e-b1e0e13fcda8.png)

## 使用gemや外部ツール
sorcery

## 確認手順

カラムを追加したので `bin/rails db:migrate` を実行してください

## 想定される影響範囲

- データベース

## コメント
画面作成のissueでしたが、設定や実装も行いました。
- 気づき
画面作成issueと機能実装issueをどこで分けるかの判断が少し戸惑いました。画面だけ作成して他は何もしないのは後で困るかと感じたので今回は設定とcontrollerの実装は行いました。

## 参考資料

公式リファレンスや参考記事へのリンク

[sorceryパスワードリセットGitHub](https://github.com/Sorcery/sorcery/wiki/Reset-password)