### PR TITLE
本番環境で正しく動作しないためエラー画面をデバッグできるものに変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true 
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]


### PR DESCRIPTION
## 概要
本番環境で画面遷移が正しく動作しなかったため、急遽issueを作らずにブランチを切り変更しました。
config/environments/development.rbの  config.consider_all_requests_local       = true に変更しました。

## コメント

- 気づき
やはり都度、本番環境でも動作確認する必要があると再認識しました。
