### PR TITLE
Mypageの作成#13

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -1,6 +1,6 @@
 class BoardsController < ApplicationController
   def index
-    @boards = Board.all.includes(:user).order(created_at: :desc).page(params[:page])
+    @boards = Board.includes(:user).order(created_at: :desc).page(params[:page])
     @favorite = Favorite.new
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,28 @@
+class ProfilesController < ApplicationController
+  before_action :set_user, only: %i[show edit update]
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path, success: 'ユーザー情報を登録しました'
+    else
+      flash.now['danger'] =  '保存できませんでした'
+      render :edit
+    end
+  end
+
+  def show
+    @boards = Board.where(user_id: current_user.id).order(created_at: :desc).page(params[:page])
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :avatar, :history, :reason)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @boards = Board.where(user_id: current_user.id).order(created_at: :desc).page(params[:page])
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,9 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
-  def show; end
+  def show
+    @user = User.find(params[:id])
+  end
 
   def create
     @user = User.new(user_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,4 +27,8 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:email, :password, :password_confirmation, :name)
   end
+
+  def mypage_params
+    params.require(:user).permit(:name, :avatar, :history, :reason)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_one_attached :avatar
+
   has_many :boards, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :favorite_boards, through: :favorites, source: :board

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,12 @@
+<div class="container">
+  <div class="row">
+    <div class="col-lg-10 offset-lg-1">
+      <h1 class="text-center"><%= current_user.name %></h4>
+      <%= image_tag @user.avatar if @user.avatar.attached? %>
+      <%= @user.history %>
+      <%= @user.reason %>
+      <%= render 'shared/form', user: @user %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,10 @@
   <div class="row">
     <div class="col-lg-10 offset-lg-1">
       <h1 class="text-center"><%= current_user.name %></h4>
-      <%= render 'shared/form', user: @user %>
+      <%= image_tag @user.avatar if @user.avatar.attached? %>
+      <%= @user.history %>
+      <%= @user.reason %>
+      <%= link_to 'ユーザー編集ページ', edit_profile_path %>
       <%= render partial: 'shared/mypage', collection: @boards, as: 'board' %>
       <%= paginate @boards %>
     </div>

--- a/app/views/shared/_form.html.erb
+++ b/app/views/shared/_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: user, local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :history %>
+    <%= f.number_field :history, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :reason %>
+    <%= f.text_area :reason, class: 'form-control' %>
+  </div>
+  <%= f.submit '登録', class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/shared/_form.html.erb
+++ b/app/views/shared/_form.html.erb
@@ -1,4 +1,12 @@
-<%= form_with model: user, local: true do |f| %>
+<%= form_with model: user, url: profile_path, local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :avatar %>
+    <%= f.file_field :avatar, class: 'form-control' %>
+  </div>
   <div class="form-group">
     <%= f.label :history %>
     <%= f.number_field :history, class: 'form-control' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-  <%= link_to 'Mypage', '#', class: 'nav-link' %>
+  <%= link_to 'Mypage', user_path(current_user), class: 'nav-link' %>
   <%= link_to 'Namikki', boards_path, class: 'nav-link' %>
   <%= link_to 'Twitter', '#', class: 'nav-link' %>
   <%= link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       <div class="navbar-nav">
-  <%= link_to 'Mypage', user_path(current_user), class: 'nav-link' %>
+  <%= link_to 'Mypage', profile_path, class: 'nav-link' %>
   <%= link_to 'Namikki', boards_path, class: 'nav-link' %>
   <%= link_to 'Twitter', '#', class: 'nav-link' %>
   <%= link_to 'ログアウト', logout_path, method: :delete, class: 'nav-link' %>

--- a/app/views/shared/_mypage.html.erb
+++ b/app/views/shared/_mypage.html.erb
@@ -1,0 +1,11 @@
+<div class="card" style="width: 18rem;">
+  <img src="..." class="card-img-top" alt="...">
+  <div class="card-body">
+    <p class="card-text"><%= board.body %></p>
+  </div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item"><%= board.wave_size %></li>
+    <li class="list-group-item"><%= board.point %></li>
+    <li class="list-group-item"><%= l board.created_at, format: :long %></li>
+  </ul>
+</div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,18 +1,18 @@
 <%= form_with model: user, local: true do |f| %>
   <div class="form-group">
-    <%= f.label :ニックネーム %>
+    <%= f.label :name %>
     <%= f.text_field :name, class: 'form-control' %>
   </div>
   <div class="form-group">
-    <%= f.label :メールアドレス %>
+    <%= f.label :email %>
     <%= f.email_field :email, class: 'form-control' %>
   </div>
   <div class="form-group">
-    <%= f.label :パスワード %>
+    <%= f.label :password %>
     <%= f.password_field :password, class: 'form-control' %>
   </div>
   <div class="form-group">
-    <%= f.label :パスワード確認 %>
+    <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, class: 'form-control' %>
   </div>
   <%= f.submit '登録', class: 'btn btn-primary' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,6 +1,0 @@
-<h1>Editing User</h1>
-
-<%= render 'form', user: @user %>
-
-<%= link_to 'Show', @user %> |
-<%= link_to 'Back', users_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,19 +1,8 @@
-<p id="notice"><%= notice %></p>
-
-<p>
-  <strong>Email:</strong>
-  <%= @user.email %>
-</p>
-
-<p>
-  <strong>Crypted password:</strong>
-  <%= @user.crypted_password %>
-</p>
-
-<p>
-  <strong>Salt:</strong>
-  <%= @user.salt %>
-</p>
-
-<%= link_to 'Edit', edit_user_path(@user) %> |
-<%= link_to 'Back', users_path %>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-10 offset-lg-1">
+      <h1 class="text-center"><%= current_user.name %></h4>
+      <%= render 'shared/form', user: @user %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,8 @@
     <div class="col-lg-10 offset-lg-1">
       <h1 class="text-center"><%= current_user.name %></h4>
       <%= render 'shared/form', user: @user %>
+      <%= render partial: 'shared/mypage', collection: @boards, as: 'board' %>
+      <%= paginate @boards %>
     </div>
   </div>
 </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true 
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,6 +12,7 @@ ja:
         name: 'ニックネーム'
         history: 'サーフィン歴'
         reason: 'はじめたきっかけ'
+        avatar: '画像'
       board:
         point: 'ポイント'
         date: '日付'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
     resource :favorites, only: %i[create destroy]
   end
   resources :password_resets, only: %i[new create edit update]
+  resource :profile, only: %i[show edit update]
 end

--- a/db/migrate/20211116041711_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20211116041711_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_08_145051) do
+ActiveRecord::Schema.define(version: 2021_11_16_041711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "boards", force: :cascade do |t|
     t.string "point"
@@ -63,6 +91,8 @@ ActiveRecord::Schema.define(version: 2021_11_08_145051) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "boards", "users"
   add_foreign_key "comments", "boards"
   add_foreign_key "comments", "users"


### PR DESCRIPTION
## 概要
close #13

追加した機能
ユーザー詳細ページ
自分の投稿のみを表示させた
![image](https://user-images.githubusercontent.com/75526672/142133098-012d9bd8-d331-4c96-ba0c-5039e77911c5.png)
ユーザー情報編集ページを作成
![image](https://user-images.githubusercontent.com/75526672/142133188-26ff8002-0562-48c4-aef6-40094631a4d3.png)



## 使用gemや外部ツール
ActiveStrageを使ってアバター画像を表示させた。

## 確認手順

2. ActiveStrageを追加したので `bin/rails db:migrate` を実行してください

## 想定される影響範囲

- データベース

## コメント

- 気づき
ユーザー詳細ページは独立したページとしてIDを持たせない方がいい点を復習できました。
アバター画像のサイズ調整やActiveStrageの本番環境の設定はまだしていないので
また別のissueで行います。

## 参考資料

[ActiveStrage](https://railsguides.jp/active_storage_overview.html)
