### PR TITLE
board詳細(show)ページの実装#15

### DIFF
--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,28 +1,21 @@
-<div class="container pt-5">
-  <div class="row mb-3">
-    <div class="col-lg-8 offset-lg-2">
-      <h1><%= @board.user.name %></h1>
-      <!-- 掲示板内容 -->
-      <article class="card">
-        <div class="card-body">
-          <div class='row'>
-            <div class='col-md-9'>
-              <h3 class="d-inline"><%= @board.user.history %><%= @board.user.reason %></h3>
-              <%= render 'crud_menus', board: @board %>
-              <ul class="list-inline">
-                <li class="list-inline-item"><%= l @board.created_at, format: :long  %></li>
-              </ul>
-            </div>
-          </div>
-          <p><%= simple_format(@board.body) %></p>
-        </div>
-      </article>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-10 offset-lg-1">
+      <h1 class="text-center"><%= @board.user.name %></h4>
+      <%= image_tag @board.user.avatar if @board.user.avatar.attached? %>
+      <%= @board.user.history %>
+      <%= @board.user.reason %>
+      <%= render 'crud_menus', board: @board %>
+      <ul class="list-inline">
+        <li class="list-inline-item"><%= l @board.created_at, format: :long  %></li>
+        <p><%= simple_format(@board.body) %></p>
+      </ul>
     </div>
-  </div>
+   </div>
+</div>
 
   <!-- コメントフォーム -->
   <%= render 'comments/form', { board: @board, comment: @comment } %>
 
   <!-- コメントエリア -->
   <%= render 'comments/comments', { comments: @comments } %>
-</div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,5 +1,6 @@
 <tr id="comment-<%= comment.id %>">
   <td>
+    <%= image_tag comment.user.avatar if comment.user.avatar.attached? %>
     <h3 class="small"><%= comment.user.name %></h3>
     <div id="js-comment-<%= comment.id %>">
       <%= simple_format(comment.body) %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
-<nav class="fixed-bottom  navbar navbar-expand-lg navbar-light bg-light">
+<nav class="fixed-bottom  navbar navbar-expand-lg navbar-light bg-light style="height: "40px">
   <div class="container-fluid">
-    <div class="btn-group text-alian-center">
+    <div class="btn-group">
       <%= link_to 'Home', root_path, class: 'navbar-brand' %>
       <%= link_to 'Namikki', boards_path, class: 'nav-link' %>
       <%= link_to 'Twitter', '#', class: 'nav-link' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
-<nav class="fixed-bottom  navbar navbar-expand-lg navbar-light bg-light">
+<nav class="fixed-bottom  navbar navbar-expand-lg navbar-light bg-light" style="height: 40px">
   <div class="container-fluid">
-    <div class="btn-group text-alian-center">
+    <div class="btn-group">
       <%= link_to 'Home', root_path, class: 'navbar-brand' %>
       <%= link_to 'Mypage', profile_path, class: 'nav-link' %>
       <%= link_to 'Namikki', boards_path, class: 'nav-link' %>


### PR DESCRIPTION
## 概要
close #15

追加した機能
![image](https://user-images.githubusercontent.com/75526672/142226447-539bfdd0-7a97-40bf-b0da-997c65a5cf39.png)

## 確認手順

一覧ページのコメントリンクからboard showページに遷移して確認できます。

## コメント
表示させたい要素は表示させられたので別のissueレイアウトの調整を行います。
