### PR TITLE
投稿一覧ページとユーザー詳細ページを無限スクロールにする#24

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,9 +8,11 @@ import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 require("jquery")
+require("jscroll")
 
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
 
 require("stylesheets/application")
+require("src/scroll")

--- a/app/javascript/src/scroll.js
+++ b/app/javascript/src/scroll.js
@@ -1,0 +1,10 @@
+$(window).on('scroll', function() {
+    scrollHeight = $(document).height();
+    scrollPosition = $(window).height() + $(window).scrollTop();
+    if ( (scrollHeight - scrollPosition) / scrollHeight <= 0.05) {
+          $('.jscroll').jscroll({
+            contentSelector: '.board-list',
+            nextSelector: 'span.next:last a'
+          });
+    }
+});

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -1,1 +1,2 @@
 @import "bootstrap";
+@import "scroll";

--- a/app/javascript/stylesheets/scroll.css
+++ b/app/javascript/stylesheets/scroll.css
@@ -1,0 +1,3 @@
+nav.pagination {
+  display: none;
+}

--- a/app/views/boards/index.html.erb
+++ b/app/views/boards/index.html.erb
@@ -1,16 +1,16 @@
 <div class="container">
-  <div class="row">
-    <div class="col-lg-10 offset-lg-1">
-      <h1 class="text-center">Namikki</h4>
-    </div>
+  <div class="col-lg-10 offset-lg-1">
+    <h1 class="text-center">Namikki</h4>
   </div>
 
-  <div class="row">
-    <% if @boards.present? %>
-      <%= render @boards %>
-    <% else %>
-      <p>投稿はありません</p>
-    <% end %>
-    <%= paginate @boards %>
+  <div class="board-list jscroll">
+    <div class="row">
+      <% if @boards.present? %>
+        <%= render @boards %>
+      <% else %>
+        <p>投稿はありません</p>
+      <% end %>
+      <%= paginate @boards %>
+    </div>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -6,7 +6,15 @@
       <%= @user.history %>
       <%= @user.reason %>
       <%= link_to 'ユーザー編集ページ', edit_profile_path %>
-      <%= render partial: 'shared/mypage', collection: @boards, as: 'board' %>
+    </div>
+  </div>
+  <div class="board-list jscroll">
+    <div class="row">
+      <% if @boards.present? %>
+        <%= render partial: 'shared/mypage', collection: @boards, as: 'board' %>
+      <% else %>
+        <p>投稿はありません</p>
+      <% end %>
       <%= paginate @boards %>
     </div>
   </div>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@rails/webpacker": "5.4.3",
     "bootstrap": "^5.1.3",
     "jquery": "^3.6.0",
+    "jscroll": "^2.4.1",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3820,6 +3820,11 @@ js-yaml@^3.13.1, js-yaml@^3.14.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jscroll@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/jscroll/-/jscroll-2.4.1.tgz#b8ea7bdbe290c577b20d00e54fb5da606f610e31"
+  integrity sha512-REd02wSyp9+mfpv8/UIHYLZD4zPJ8Bqy5dN9x/DpZ5t/ivRZosEF2AjriZ/PKikx48/o+Ep6xAsNiZ6S26X2LQ==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"


### PR DESCRIPTION
## 概要
close #24

追加した機能
ページネーションで実装していたページを無限スクロールにしました。

## 使用gemや外部ツール
yarnでjscrollをインストールしました。

## 確認手順

`yarn add jscroll` を実行してください。

## 想定される影響範囲
yarn.lock

## コメント
- 気づき
yarnでインストールできるという記事はなく公式を見て実装しました。
プラグインやgem等は、公式を確認するクセをつけるようにします。

## 参考資料
[jscroll公式](https://jscroll.com/#/usage)
