### PR TITLE
herokuデプロイ時のコンパイルエラー対策

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,10 +25,10 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress CSS using a preprocessor.
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = :scss
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true 
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
## 概要
デプロイ時にコンパイルエラーが出たので、エラー内容からググりscssに変更した事を設定に追記する必要がある事がわかり急遽branchを切りプルリクしました。

## コメント
- 気づき
ローカルで正常に動作していてもデプロイ時にエラーが発生すると原因を特定するのが今は難しく感じるので、こうしてエラーに発生するたびに向き合って学んでいきたいです。

## 参考資料
[Herokuでgit push heroku masterした時にrejectされたら見る記事](https://qiita.com/tomomomo1217/items/fa8dfa094cc4c0e4e350)
