### PR TITLE
Herokuデプロイのデバッグ

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
+  config.require_master_key = true
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,6 +3,10 @@ CarrierWave.configure do |config|
     provider: 'AWS',
     aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
     aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
+    secret_key_base: Rails.application.credentials[:secret_key_base],
     region: 'ap-northeast-1'
   }
+
+    config.fog_directory  = 'rails-namikki'
+    config.cache_storage = :fog
 end


### PR DESCRIPTION
## 概要
herokuデプロイ時にcarrier_waveのAPI keyがnilになっているエラーがあったので原因を追求したところ、secret_keyが設定されていないからデプロイがうまくいかないのではないかと考え、設定に追記しました。rails cでは取得できていたAPIkeyが、heroku run rails c でAPIkeyがnilになっていたのが原因かと考えました。

## コメント
- 気づき
herokuデプロイ時のエラーは向き合って場数を踏んでいきたいので今回のエラーはありがたいと思いました。

## 参考資料
[carrier_waveの設定追記](https://qiita.com/junara/items/1899f23c091bcee3b058)
