### PR TITLE
herokuデプロイのデバッグ uploaderの小文字を大文字に修正

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,5 +1,5 @@
 class ImageUploader < CarrierWave::Uploader::Base
-  include carrierwave::minimagick
+  include CarrierWave::MiniMagick
   process resize_to_limit: [300, 200]
 
   if Rails.env.development?


### PR DESCRIPTION
## 概要
Applicationエラーが出てheroku run rails cで原因を究明し、ファイルの変更点としてはuploader内の小文字を大文字に修正したのですが
herokuのデプロイのデバッグとしてはherokuにmaster_keyを設定することで解決しました。

## コメント
- 気づき
herokuにもmaster_keyを登録しないとデプロイできないことを学びました。

## 参考資料
[heroku にmaster_keyを設定](https://qiita.com/gonza_kato_atsushi/items/8a4829207df2316a9e8c)
