### PR TITLE
Turbolinks無効化によるページリロードなしで背景画像全画面表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'sass-rails', '>= 6'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 5.0'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -606,9 +606,6 @@ GEM
     thor (1.1.0)
     tilt (2.0.10)
     trailblazer-option (0.1.2)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
@@ -677,7 +674,6 @@ DEPENDENCIES
   sass-rails (>= 6)
   sorcery
   spring
-  turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)
   webdrivers

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,14 +4,14 @@
 // that code so it'll be compiled.
 
 import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
+// import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 require("jquery")
 require("jscroll")
 
 Rails.start()
-Turbolinks.start()
+// Turbolinks.start()
 ActiveStorage.start()
 
 require.context("../images", true)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application', media: 'all' %>
+    <%= javascript_pack_tag 'application' %>
   </head>
 
   <body>


### PR DESCRIPTION
## 概要
close #39

追加した機能
Turbolinks導入時にリンクからの画面遷移での背景画面の状態
JSが効いていないため、画像が途切れている。
![image](https://user-images.githubusercontent.com/75526672/143667038-9031c4a6-999d-40e7-b56d-2bd54d98c888.png)

Turbolinksを無効化した後
![image](https://user-images.githubusercontent.com/75526672/143667052-47eca19c-4faa-4b3b-8bed-0728a3f07585.png)
全画面表示ができ改善されました。

## 確認手順

1. Turbolinksをコメントアウトしたので `bundle update turbolinks` を実行してください

## 想定される影響範囲
Gemfile.lock

## コメント
- 気づき
Turbolinksで望んだ挙動が得られないパターンを学習して知識があったため、すぐに原因を突き止められました。

## 参考資料

[Turbolinks無効化](https://qiita.com/matsubishi5/items/c4c8a5df03ae630ae534)
