### PR TITLE
logged_in?を使いログイン前とログイン後のパーシャルを作成し表示を切り替える

### DIFF
--- a/app/views/boards/_before_login_index.html.erb
+++ b/app/views/boards/_before_login_index.html.erb
@@ -1,0 +1,4 @@
+<div class="caption">
+  <%= link_to 'いいね', login_path  %>
+  <%= link_to 'コメント', login_path %>
+</div>

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -15,15 +15,9 @@
   <div class="card-comment">
     <p><%= board.body %></p>
   </div>
-  <div class="caption">
-    <% if current_user.favorites.find_by(board_id: board.id) %>
-      <%= render 'unfavorite', board: board %>
-    <% else %>
-      <%= render 'favorite', board: board %>
-    <% end %>
-    <%= link_to 'コメント', board_path(board) %>
-  </div>
-  <div class="card-delete-btn">
-    <%= render 'crud_menus', board: board if current_user.own?(board) %>
-  </div>
+  <% if logged_in? %>
+    <%= render 'login_index', board: board %>
+  <% else %>
+    <%= render 'before_login_index' %>
+  <% end %>
 </div>

--- a/app/views/boards/_login_index.html.erb
+++ b/app/views/boards/_login_index.html.erb
@@ -1,0 +1,11 @@
+<div class="caption">
+   <% if current_user.favorites.find_by(board_id: board.id) %>
+     <%= render 'unfavorite', board: board %>
+   <% else %>
+     <%= render 'favorite', board: board %>
+   <% end %>
+     <%= link_to 'コメント', board_path(board) %>
+</div>
+<div class="card-delete-btn">
+  <%= render 'crud_menus', board: board if current_user.own?(board) %>
+</div>


### PR DESCRIPTION
## 概要
close #47

追加した機能
ログイン前でNamikkiページに遷移しログイン後に使える機能に関してはログインページに遷移させるように実装しました。

## コメント
- 気づき
sorceryのlogged_in?メソッドを使い簡単に実装できました。

## 参考資料

[logged_in?](https://qiita.com/d0ne1s/items/7c4d2be3f53e34a9dec7#ログイン状態に応じてトップページの表示を切り分け)