### PR TITLE
productionでのpassword_reset時に発生しているエラー文から推測される項目を追記した

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = {  :host => 'https://namikki.herokuapp.com/' }
   config.action_mailer.smtp_settings = {
     address:              'smtp.gmail.com',
     port:                 587,


### PR DESCRIPTION
## 概要
#53

## コメント
- 気づき
configでのproduction環境でのエラーをデプロイ後でなくとも確認できる方法があるか模索します。(それほど起こらないだろうと思っていたが多発してその都度issueとbranchを作りプルリクを書いた上で動作を確認するのは大変ですね)
## 参考資料

[ArgumentError (Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true):'が出たときの対処法](https://qiita.com/hirochan/items/7c4f24bf05d9de8a196b)
