### PR TITLE
Fix:ogp画像のパスを修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <meta property="og:url" content="https://namikki.herokuapp.com/" />
     <meta property="og:title" content="Namikki" /> 
     <meta property="og:description" content="サーフィン日記共有サービスです" /> 
-    <meta property="og:image" content="https://namikki.herokuapp.com/packs/media/images/ogp.jpeg" />
+    <meta property="og:image" content="https://namikki.herokuapp.com/packs/media/images/ogp-82c3ea9c0a0e40dbea787b9b7eede86e.jpeg" />
   </head>
 
   <body>


### PR DESCRIPTION
## 概要
close #56 

## コメント
OGP画像が反映されなかったので、実際に画像を表示させてパスを見てみたところ、生成されていたパスと違ったので修正しました。