### PR TITLE
Fix:タイポの修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <meta name="twitter:site" content="@otokomigakimasu" />
     <meta property="og:url" content="https://www.namikki.jp/" />
     <meta property="og:title" content="Namikki" /> 
-    <meta peoperty="og:description" content="伊良湖エリアのサーフィン日記共有サービスです" /> 
+    <meta property="og:description" content="伊良湖エリアのサーフィン日記共有サービスです" /> 
     <meta property="og:image" content="https://www.namikki.jp/packs/media/images/ogp-97563fe78ecc9a4595d34905f0f72a6f.jpeg" />
 
     <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
## 概要
いつの間にか起こっていたURLのタイポを修正しました。

## コメント
作業を急いでいてのミスですが、最後にGitHub上でのコミット変更差分をきちんと見るクセをつけようと思えたので良かったです。

## 参考資料
特になし
