### PR TITLE
パスワードリセットのメール内のURLをドメイン取得後のものに修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = {  :host => 'https://namikki.herokuapp.com/' }
+  config.action_mailer.default_url_options = {  :host => 'https://www.namikki.jp/' }
   config.action_mailer.smtp_settings = {
     address:              'smtp.gmail.com',
     port:                 587,


### PR DESCRIPTION
## 概要
close #85

## 追加した機能
パスワードリセットで送られるURLをドメイン取得後のものに修正しました。

## 確認手順

パスワードリセットを行なってください。

## コメント
実装終了間際にドメインを取得したのでそれまでにURLを記述したものがherokuappのものだったというのが盲点でした。

## 参考資料

特になし
