### PR TITLE
画像をフィルターで実装する

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path, success: 'ユーザー登録が完了しました'
+      auto_login(@user)
+      redirect_to root_path, success: 'ユーザー登録が完了しました'
     else
       render :new
     end

--- a/app/javascript/stylesheets/boards.scss
+++ b/app/javascript/stylesheets/boards.scss
@@ -16,6 +16,11 @@
 }
 
 // Namikkiページ
+
+.board-name {
+  font-size: 20px;
+}
+
 .card {
   margin-right: auto;
   margin-left: auto;

--- a/app/javascript/stylesheets/images.scss
+++ b/app/javascript/stylesheets/images.scss
@@ -37,15 +37,11 @@
   z-index: -1;
 }
 
-.description-img::after {
-  filter: brightness(200%);
-}
-
 .description-img img {
   position: relative;
   width: 100%;
   height: auto;
-  filter: brightness(150%);
+  filter: saturate(200%) brightness(120%) contrast(200%);
 }
 
 .boards-img {

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -7,7 +7,7 @@
     <% end %>
     <p class="list-group-item"><%= l board.created_at, format: :long %></p>
     <div class="card-body">
-      <p><%= board.user.name %></p>
+      <p class="board-name"><%= board.user.name %></p>
    </div>
     <div class="card-comment">
       <p><%= board.body %></p>

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -5,7 +5,7 @@
         <h1 class="title">Namikki</h1>
         <p class="text-center">伊良湖赤羽根エリアのサーファーのためのサーフィン日記共有サービスです</p>
         <%= render 'boards/form', board: @board %>
-        <%= link_to 'まずプロフィールを登録する', edit_profile_path, class: 'board-link', style: 'margin: 10% 0 20% 0' %>
+          <%= link_to 'Mypageを見てみる', profile_path, class: 'board-link', style: 'margin: 10% 0 20% 0' %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -2,21 +2,21 @@
 <% when "雲" %>
   <%= image_tag(asset_pack_path("media/images/cloud.jpeg")) %>
 <% when "曇りがち" %>
-  <%= image_tag(asset_pack_path("media/images/brokencloud.jpeg")) %>
+  <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "薄い雲" %>
-  <%= image_tag(asset_pack_path("media/images/fewcloud.jpeg")) %>
+  <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "厚い雲" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "小雨" %>
   <%= image_tag(asset_pack_path("media/images/showerrain.jpeg")) %>
 <% when "適度な雨" %>
-  <%= image_tag(asset_pack_path("media/images/rain.jpeg")) %>
+  <%= image_tag(asset_pack_path("media/images/showerrain.jpeg")) %>
 <% when "雨" %>
-  <%= image_tag(asset_pack_path("media/images/rain.jpeg")) %>
+  <%= image_tag(asset_pack_path("media/images/showerrain.jpeg")) %>
 <% when "強い雨" %>
-  <%= image_tag(asset_pack_path("media/images/rain.jpeg")) %>
+  <%= image_tag(asset_pack_path("media/images/showerrain.jpeg")) %>
 <% when "雷雨" %>
-  <%= image_tag(asset_pack_path("media/images/rain.jpeg")) %>
+  <%= image_tag(asset_pack_path("media/images/showerrain.jpeg")) %>
 <% when "晴天" %>
   <%= image_tag(asset_pack_path("media/images/sun.jpeg")) %>
 <% when "雪" %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -7,7 +7,7 @@
         <%= link_to 'Namikkiを投稿する', new_board_path, class: 'board-link' %>
         <%= render 'shared/weather' %>
         <% if logged_in? %>
-          <%= link_to 'Mypageを見てみる', profile_path, class: 'board-link', style: 'margin-bottom: 20%' %>
+          <%= link_to 'まずプロフィールを登録する', edit_profile_path, class: 'board-link', style: 'margin-bottom: 20%' %>
         <% else %>
           <%= link_to '登録する前にNamikkiを見てみる', boards_path, class: 'board-link', style: 'margin-bottom: 20%' %>
         <% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## 概要
#87

## 追加した機能
背景画像のフィルターをつけてコントラストと明るさを調整して文字を見えやすいようにしました。
![image](https://user-images.githubusercontent.com/75526672/147099235-aa664e15-3b4f-4f82-8d99-1a18b60cbb04.png)

現段階で全ての背景画像というわけにはいかなかったので、ひとまず問題のない背景画像のみにしました。

その他、herokuのSSL化の設定とユーザー登録時にauto_loginを実装し二度手間になっているのを改善しました。


## 使用gemや外部ツール

## コメント
背景の画像を活かすならば文字を白くして、背景画像を暗くするフィルターで実装した方がいいのかも知れないなって感じています。ここはまだ検討中なのでissueは閉じずにおきますが、現段階で本番環境に反映させたい変更点があったのでマージします。

## 参考資料
[CSS filter](https://code-kitchen.dev/css/filter/#brightness%EF%BC%8830%25%E6%98%8E%E5%BA%A6%EF%BC%89)