### PR TITLE
Fix:fogをfor-awsに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'cancancan'
 gem 'carrierwave'
 gem 'config'
-gem 'fog'
+gem 'fog-aws'
 gem 'kaminari'
 gem 'mini_magick'
 gem 'rails_admin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
     actioncable (6.1.4.1)
       actionpack (= 6.1.4.1)
       activesupport (= 6.1.4.1)
@@ -67,9 +66,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    aliyun-sdk (0.8.0)
-      nokogiri (~> 1.6)
-      rest-client (~> 2.0)
     ast (2.4.2)
     bcrypt (3.1.16)
     better_errors (2.9.1)
@@ -115,11 +111,8 @@ GEM
       dry-validation (~> 1.0, >= 1.0.0)
     crass (1.0.6)
     debug_inspector (1.1.0)
-    declarative (0.0.20)
     deep_merge (1.2.1)
     diff-lcs (1.4.4)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
     dry-configurable (0.13.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.6)
@@ -154,7 +147,7 @@ GEM
       dry-schema (~> 1.8, >= 1.8.0)
     erubi (1.10.0)
     erubis (2.7.0)
-    excon (0.88.0)
+    excon (0.89.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -180,215 +173,28 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     ffi (1.15.4)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (2.2.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.4)
-      fog-cloudstack (~> 0.1.0)
-      fog-core (~> 2.1)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 2.1)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (~> 1.0)
-      fog-internet-archive
-      fog-json
-      fog-local
-      fog-openstack
-      fog-ovirt
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (~> 2.0)
-    fog-aliyun (0.3.19)
-      aliyun-sdk (~> 0.8.0)
-      fog-core
-      fog-json
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
     fog-aws (3.12.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.16.1)
-      dry-inflector
-      fog-core
-      fog-json
-      mime-types
-    fog-cloudatcost (0.4.0)
-      fog-core
-      fog-json
-      ipaddress
-    fog-cloudstack (0.1.0)
-      fog-core (~> 2.1)
-      fog-json (~> 1.1)
-      fog-xml (~> 0.1)
-    fog-core (2.1.0)
+    fog-core (2.2.4)
       builder
-      excon (~> 0.58)
+      excon (~> 0.71)
       formatador (~> 0.2)
       mime-types
-    fog-digitalocean (0.4.0)
-      fog-core
-      fog-json
-      fog-xml
-      ipaddress (>= 0.5)
-    fog-dnsimple (2.1.0)
-      fog-core (>= 1.38, < 3)
-      fog-json
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (1.17.0)
-      fog-core (<= 2.1.0)
-      fog-json (~> 1.2)
-      fog-xml (~> 0.1.0)
-      google-apis-compute_v1 (~> 0.14)
-      google-apis-dns_v1 (~> 0.12)
-      google-apis-iamcredentials_v1 (~> 0.6)
-      google-apis-monitoring_v3 (~> 0.12)
-      google-apis-pubsub_v1 (~> 0.7)
-      google-apis-sqladmin_v1beta4 (~> 0.13)
-      google-apis-storage_v1 (~> 0.6)
-      google-cloud-env (~> 1.2)
-    fog-internet-archive (0.0.2)
-      fog-core
-      fog-json
-      fog-xml
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    fog-local (0.7.0)
-      fog-core (>= 1.27, < 3.0)
-    fog-openstack (1.0.11)
-      fog-core (~> 2.1)
-      fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    fog-ovirt (2.0.1)
-      activesupport
-      fog-core
-      fog-json
-      fog-xml
-      ovirt-engine-sdk (>= 4.3.1)
-    fog-powerdns (0.2.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-profitbricks (0.0.5)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-rackspace (0.1.6)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.4)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (3.5.0)
-      fog-core
-      rbvmomi (>= 1.9, < 3)
-    fog-xenserver (1.0.0)
-      fog-core
-      fog-xml
-      xmlrpc
     fog-xml (0.1.4)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.3.0)
     globalid (0.5.2)
       activesupport (>= 5.0)
-    google-apis-compute_v1 (0.20.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-core (0.4.1)
-      addressable (~> 2.5, >= 2.5.1)
-      googleauth (>= 0.16.2, < 2.a)
-      httpclient (>= 2.8.1, < 3.a)
-      mini_mime (~> 1.0)
-      representable (~> 3.0)
-      retriable (>= 2.0, < 4.a)
-      rexml
-      webrick
-    google-apis-dns_v1 (0.16.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-iamcredentials_v1 (0.8.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-monitoring_v3 (0.17.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-pubsub_v1 (0.9.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-sqladmin_v1beta4 (0.20.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-storage_v1 (0.9.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-cloud-env (1.5.0)
-      faraday (>= 0.17.3, < 2.0)
-    googleauth (1.1.0)
-      faraday (>= 0.17.3, < 2.0)
-      jwt (>= 1.4, < 3.0)
-      memoist (~> 0.16)
-      multi_json (~> 1.11)
-      os (>= 0.9, < 2.0)
-      signet (>= 0.16, < 2.a)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
-    http-accept (1.7.0)
-    http-cookie (1.0.4)
-      domain_name (~> 0.5)
-    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
@@ -435,7 +241,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    memoist (0.16.2)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -449,7 +254,6 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nested_form (0.3.2)
-    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
@@ -461,10 +265,6 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    optimist (3.0.1)
-    os (1.1.4)
-    ovirt-engine-sdk (4.4.1)
-      json (>= 1, < 3)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -543,24 +343,9 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbvmomi (2.4.1)
-      builder (~> 3.0)
-      json (>= 1.8)
-      nokogiri (~> 1.5)
-      optimist (~> 3.0)
     regexp_parser (2.1.1)
     remotipart (1.4.4)
-    representable (3.1.1)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
     require_all (3.0.0)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    retriable (3.1.2)
     rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -615,11 +400,6 @@ GEM
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
     sexp_processor (4.15.3)
-    signet (0.16.0)
-      addressable (~> 2.8)
-      faraday (>= 0.17.3, < 2.0)
-      jwt (>= 1.5, < 3.0)
-      multi_json (~> 1.10)
     sorcery (0.16.1)
       bcrypt (~> 3.1)
       oauth (~> 0.5, >= 0.5.5)
@@ -636,13 +416,8 @@ GEM
     temple (0.8.2)
     thor (1.1.0)
     tilt (2.0.10)
-    trailblazer-option (0.1.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    uber (0.1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
     uniform_notifier (1.14.2)
     web-console (4.1.0)
@@ -659,14 +434,9 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xml-simple (1.1.9)
-      rexml
-    xmlrpc (0.3.2)
-      webrick
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.1)
@@ -686,7 +456,7 @@ DEPENDENCIES
   carrierwave
   config
   factory_bot_rails
-  fog
+  fog-aws
   jbuilder (~> 2.7)
   kaminari
   letter_opener_web


### PR DESCRIPTION
## 概要
いきなり本番環境でアプリがエラーになってしまったのでheroku run rails c を行ったエラー内容をもとにデバッグを行いました。
```
[fog][DEPRECATION] Fog::Storage::AWS is deprecated, please use Fog::AWS::Storage.
[fog][WARNING] Unrecognized arguments: aws_access_key_id, aws_secret_access_key, secret_key_base, region, path_style
```

## 追加した機能
Gem の fogをfog-awsに変更しました。

## 確認手順

1. Gem を変更したので `bundle update fog-aws` を実行してください


## 想定される影響範囲
- gem

## コメント
昨晩まで通常通り動作していて朝起きたらエラーになっていたのでびっくりしました。

## 参考資料

[fogをfog-awsに](https://halkyo.com/web/fogdeprecation-wasabi-rails-connect/)
