### PR TITLE
本番環境で雪を降らせる

### DIFF
--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -3,7 +3,6 @@
   <%= image_tag(asset_pack_path("media/images/cloud.jpeg")) %>
 <% when "曇りがち" %>
   <%= image_tag(asset_pack_path("media/images/bluecloud.jpeg")) %>
-  <%= javascript_pack_tag 'weathers/snowfall' %>
 <% when "薄い雲" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "厚い雲" %>
@@ -37,8 +36,10 @@
   <%= image_tag(asset_pack_path("media/images/sun.jpeg")) %>
 <% when "雪" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
+  <%= javascript_pack_tag 'weathers/snowfall' %>
 <% when "小雪" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
+  <%= javascript_pack_tag 'weathers/snowfall' %>
 <% when "霧" %>
   <%= image_tag(asset_pack_path("media/images/mist.jpeg")) %>
 <% end %>

--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -3,8 +3,6 @@
   <%= image_tag(asset_pack_path("media/images/cloud.jpeg")) %>
 <% when "曇りがち" %>
   <%= image_tag(asset_pack_path("media/images/bluecloud.jpeg")) %>
-  <%= javascript_pack_tag 'weathers/snowfall' %>
-  <%= stylesheet_pack_tag 'weathers/snowfall' %>
 <% when "薄い雲" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "厚い雲" %>

--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -3,6 +3,7 @@
   <%= image_tag(asset_pack_path("media/images/cloud.jpeg")) %>
 <% when "曇りがち" %>
   <%= image_tag(asset_pack_path("media/images/bluecloud.jpeg")) %>
+  <%= javascript_pack_tag 'weathers/snowfall' %>
 <% when "薄い雲" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "厚い雲" %>

--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -3,6 +3,8 @@
   <%= image_tag(asset_pack_path("media/images/cloud.jpeg")) %>
 <% when "曇りがち" %>
   <%= image_tag(asset_pack_path("media/images/bluecloud.jpeg")) %>
+  <%= javascript_pack_tag 'weathers/snowfall' %>
+  <%= stylesheet_pack_tag 'weathers/snowfall' %>
 <% when "薄い雲" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "厚い雲" %>

--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -1,12 +1,8 @@
 <% case @lists[0]["weather"][0]["description"] %>
 <% when "雲" %>
   <%= image_tag(asset_pack_path("media/images/cloud.jpeg")) %>
-  <%= javascript_pack_tag 'weathers/snowfall' %>
-  <%= stylesheet_pack_tag 'weathers/snowfall' %>
 <% when "曇りがち" %>
   <%= image_tag(asset_pack_path("media/images/bluecloud.jpeg")) %>
-  <%= javascript_pack_tag 'weathers/snowfall' %>
-  <%= stylesheet_pack_tag 'weathers/snowfall' %>
 <% when "薄い雲" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "厚い雲" %>

--- a/app/views/shared/_images.html.erb
+++ b/app/views/shared/_images.html.erb
@@ -1,8 +1,12 @@
 <% case @lists[0]["weather"][0]["description"] %>
 <% when "雲" %>
   <%= image_tag(asset_pack_path("media/images/cloud.jpeg")) %>
+  <%= javascript_pack_tag 'weathers/snowfall' %>
+  <%= stylesheet_pack_tag 'weathers/snowfall' %>
 <% when "曇りがち" %>
   <%= image_tag(asset_pack_path("media/images/bluecloud.jpeg")) %>
+  <%= javascript_pack_tag 'weathers/snowfall' %>
+  <%= stylesheet_pack_tag 'weathers/snowfall' %>
 <% when "薄い雲" %>
   <%= image_tag(asset_pack_path("media/images/thickcloud.jpeg")) %>
 <% when "厚い雲" %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -7,6 +7,7 @@ CarrierWave.configure do |config|
     provider: 'AWS',
     aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
     aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
+    secret_key_base: Rails.application.credentials[:secret_key_base],
     region: 'ap-northeast-1',
     path_style: true
   }

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -7,7 +7,6 @@ CarrierWave.configure do |config|
     provider: 'AWS',
     aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
     aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
-    secret_key_base: Rails.application.credentials[:secret_key_base],
     region: 'ap-northeast-1',
     path_style: true
   }


### PR DESCRIPTION
## 概要
close #104

## 追加した機能
本番環境でもsnowfallを読み込めるようにしました。`heroku run rails c`を実行したときに出ていたfogのエラーをデバッグしました。

## 確認手順
`brew upgrade yarn` 
`bundle exec rails webpacker:install`を実行してください。

## 想定される影響範囲
- yarn
- webpacker

## コメント
JQueryのプラグインを入れるときに`javascript_pack_tag`と一緒に`stylesheet_pack_tag`も必要だという思い込みとローカルでは正常に動いていた事から気づけなかったエラーでした。本番環境での挙動もしっかり見なければという意識が新たになりました。またfogの設定では`secret_key_base`は不要だったようで記事を参考に設定をしていましたが、一つ一つの設定の意義を考えながらする事を気をつけます。
`heroku logs`というコマンドで本番環境のログを見ることでエラーの原因を確かめる重要性も学べました。

## 参考資料

[fogの設定](https://qiita.com/matsubishi5/items/96721426cff2b1d67cdd)

[本番環境のログを見る](https://qiita.com/jnchito/items/9d4ca74c678eaf799b3a)
