### PR TITLE
Fix:通知一覧が重複して表示されていたのを冒頭の一つに修正

### DIFF
--- a/app/views/notices/_notice.html.erb
+++ b/app/views/notices/_notice.html.erb
@@ -4,7 +4,6 @@
   <div class="row">
     <div class="top-wrapper">
       <div class=" col-md-10 offset-md-1 col-lg-8 offset-lg-2">
-        <p class="notice-p">通知一覧</p>
         <span>
           <%= link_to notice.board do %>
             <% if visitor.avatar.url.present? %>

--- a/app/views/notices/index.html.erb
+++ b/app/views/notices/index.html.erb
@@ -7,8 +7,10 @@
     <div class="row">
       <% notices = @notices.where.not(visitor_id: current_user.id) %>
       <% if notices.exists? %>
+        <p class="notice-p">通知一覧</p>
         <%= render notices %>
       <% else %>
+        <p class="notice-p">通知一覧</p>
         <p> 通知はありません </p>
       <% end %>
       <%= paginate notices %>


### PR DESCRIPTION
## 概要
通知一覧が重複して表示されていたのを冒頭の一つに修正しました。

## 追加した機能
修正前
![image](https://user-images.githubusercontent.com/75526672/148540622-9d6e40b2-33a8-4595-a9c7-91f4ef7a5001.png)

修正後
![image](https://user-images.githubusercontent.com/75526672/148540668-d7aabf2f-e826-4137-bef6-d198fc0ad4ca.png)

## コメント
こういったところに気づけるように自分で自分のサービスをどんどん使っていきます！

## 参考資料
特になし
