### PR TITLE
ユーザー詳細ページの作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @boards = Board.where(user_id: current_user.id).order(created_at: :desc).page(params[:page])
+    @boards = @user.boards.order(created_at: :desc).page(params[:page])
   end
 
   def create

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -1,12 +1,14 @@
 <div class="container">
   <div class="row">
     <div class="comment-layout col-lg-10 offset-lg-1">
-      <h1 class="title"><%= @board.user.name %></h4>
+    <%= link_to current_user.own?(@board) ? profile_path : user_path(@board.user) do %>
+      <h1 class="title"><%= @board.user.name %></h1>
       <% if @board.user.avatar.url.present? %>
         <%= image_tag @board.user.avatar.url, class: 'avatar-img' %>
       <% else %>
         <%= image_tag(asset_pack_path("media/images/sample.jpg"), class: 'avatar-img') %>
       <% end %>
+    <% end %>
       <div class="history">
         <p>サーフィン歴<%= @board.user.history %>年</p>
       </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,11 +1,13 @@
 <tr id="comment-<%= comment.id %>">
   <td>
+    <%= link_to current_user.own?(comment) ? profile_path : user_path(@board.user) do %>
       <% if comment.user.avatar.url.present? %>
         <%= image_tag comment.user.avatar.url, class: 'comment-avatar-img' %>
       <% else %>
         <%= image_tag(asset_pack_path("media/images/sample.jpg"), class: 'comment-avatar-img') %>
       <% end %>
     <h3 class="comment-name comments-css small"><%= comment.user.name %></h3>
+  <% end %>
     <div id="js-comment-<%= comment.id %>">
       <%= simple_format(comment.body, class: 'comment-css') %>
       <p class='comment-time'><%= time_ago_in_words(comment.created_at).upcase %>前</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,10 +6,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= favicon_pack_tag('favicon.ico') %>
-
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
+
+    <%= favicon_pack_tag('favicon.ico') %>
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@otokomigakimasu" />

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,29 @@
+<div class="container">
+  <div class="row">
+    <div class="mypage-layout col-lg-10 offset-lg-1">
+      <h1 class="title"><%= @user.name %></h1>
+      <% if @user.avatar.url.present? %>
+        <%= image_tag @user.avatar.url, class: 'avatar-img', size: '300x200' %>
+      <% else %>
+        <%= image_tag(asset_pack_path("media/images/sample.jpg"), class: 'avatar-img') %>
+      <% end %>
+      <div class="history"
+        <p>サーフィン歴<%= @user.history %>年</p>
+      </div>
+      <div class="reason">
+        <p>はじめたきっかけ</p>
+        <%= @user.reason %>
+      </div>
+    </div>
+  </div>
+  <div class="board-list jscroll">
+    <div class="row">
+      <% if @boards.present? %>
+        <%= render partial: 'shared/mypage', collection: @boards, as: 'board' %>
+      <% else %>
+        <p>投稿はありません</p>
+      <% end %>
+      <%= paginate @boards %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
       <% else %>
         <%= image_tag(asset_pack_path("media/images/sample.jpg"), class: 'avatar-img') %>
       <% end %>
-      <div class="history"
+      <div class="history">
         <p>サーフィン歴<%= @user.history %>年</p>
       </div>
       <div class="reason">

--- a/spec/factories/boards.rb
+++ b/spec/factories/boards.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :board do
     point { "ロングビーチ" }
     wave_size { "フラット" }
-    user_id { 1 }
+    sequence(:user_id, "1")
     association :user
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :comment do
     body { "テストコメント" }
-    user_id { 1 }
-    board_id { 1 }
+    sequence(:user_id, "1")
+    sequence(:board_id, "1")
     association :user
     association :board
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     password_confirmation { "password" }
     reason { "楽しかったから" }
     role { 0 }
+    sequence(:id, "1")
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -192,6 +192,46 @@ RSpec.describe "Users", type: :system do
           expect(current_path).to eq board_path(board)
         end
       end
+
+      context '他者のコメントページからユーザー詳細ページにアクセス' do
+        it 'ユーザー名をクリックするとユーザー詳細ページが表示される' do
+          visit boards_path
+          find('.card').click
+          find('.title').click
+          expect(current_path).to eq user_path(board.user)
+        end
+        it 'ユーザーアイコンをクリックするとユーザー詳細ページが表示される' do
+          visit boards_path
+          find('.card').click
+          find('.avatar-img').click
+          expect(current_path).to eq user_path(board.user)
+        end
+      end
+
+      context '自身のコメントページからMypageにアクセス' do
+        it 'ユーザー名をクリックするとプロフィールページが表示される' do
+          visit new_board_path
+          select "ロコ", from: "board_point"
+          select "フラット", from: "board_wave_size"
+          execute_script('window.scrollBy(0,800)')
+          fill_in "コメント", with: "二つ目の投稿"
+          click_on "投稿"
+          click_on "ロコ"
+          find('.title').click
+          expect(current_path).to eq profile_path
+        end
+        it 'ユーザーのアイコンをクリックするとプロフィールページが表示される' do
+          visit new_board_path
+          select "ロコ", from: "board_point"
+          select "フラット", from: "board_wave_size"
+          execute_script('window.scrollBy(0,800)')
+          fill_in "コメント", with: "二つ目の投稿"
+          click_on "投稿"
+          click_on "ロコ"
+          find('.avatar-img').click
+          expect(current_path).to eq profile_path
+        end
+      end
     end
 
     describe 'プロフィール編集機能' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe "Users", type: :system do
   let(:user) { build(:user) }
   let!(:board) { create(:board) }
+  let(:comment) { build(:comment) }
 
   describe 'ログイン前' do
     before do
@@ -229,6 +230,72 @@ RSpec.describe "Users", type: :system do
           click_on "投稿"
           click_on "ロコ"
           find('.avatar-img').click
+          expect(current_path).to eq profile_path
+        end
+      end
+
+      context '他者のコメントからユーザー詳細ページへアクセス' do
+        it 'コメントの名前をクリックするとユーザー詳細ページが表示される' do
+          visit boards_path
+          click_on 'ロングビーチ'
+          execute_script('window.scrollBy(0,2000)')
+          sleep 2
+          fill_in 'コメント ※150文字まで', with: 'テストコメント'
+          click_on '投稿'
+          visit new_user_path
+          fill_in 'ニックネーム', with: 'test2'
+          fill_in 'メールアドレス', with: 'test2@exanple.com'
+          fill_in 'パスワード     ※4文字以上', with: "password"
+          fill_in 'パスワード確認', with: "password"
+          click_button '登録'
+          visit boards_path
+          click_on 'ロングビーチ'
+          execute_script('window.scrollBy(0,2000)')
+          sleep 2
+          find('.comment-name').click
+          expect(current_path).to eq user_path(board.user)
+        end
+        it 'コメントのアイコンをクリックするとユーザー詳細ページが表示される' do
+          visit boards_path
+          click_on 'ロングビーチ'
+          execute_script('window.scrollBy(0,2000)')
+          sleep 2
+          fill_in 'コメント ※150文字まで', with: 'テストコメント'
+          click_on '投稿'
+          visit new_user_path
+          fill_in 'ニックネーム', with: 'test2'
+          fill_in 'メールアドレス', with: 'test2@exanple.com'
+          fill_in 'パスワード     ※4文字以上', with: "password"
+          fill_in 'パスワード確認', with: "password"
+          click_button '登録'
+          visit boards_path
+          click_on 'ロングビーチ'
+          execute_script('window.scrollBy(0,2000)')
+          sleep 2
+          find('.comment-avatar-img').click
+          expect(current_path).to eq user_path(board.user)
+        end
+      end
+
+      context '自身のコメントからプロフィールページへアクセス' do
+        it 'コメントの名前をクリックするとするとプロフィールページが表示される' do
+          visit boards_path
+          click_on 'ロングビーチ'
+          execute_script('window.scrollBy(0,2000)')
+          sleep 2
+          fill_in 'コメント ※150文字まで', with: 'テストコメント'
+          click_on '投稿'
+          find('.comment-name').click
+          expect(current_path).to eq profile_path
+        end
+        it 'コメントのアイコンをクリックするとプロフィールページが表示される' do
+          visit boards_path
+          click_on 'ロングビーチ'
+          execute_script('window.scrollBy(0,2000)')
+          sleep 2
+          fill_in 'コメント ※150文字まで', with: 'テストコメント'
+          click_on '投稿'
+          find('.comment-avatar-img').click
           expect(current_path).to eq profile_path
         end
       end


### PR DESCRIPTION
## 概要
close #111

## 追加した機能
他者のコメントページの名前もしくはアイコンからユーザー詳細ページへ遷移します。(自身のものならプロフィールページへ遷移します)
https://i.gyazo.com/e62ee751a4d070989d99028a8d6324c2.gif

他者のコメントの名前もしくはアイコンからユーザー詳細ページへ遷移します。(自身のものならプロフィールページへ遷移します)
https://i.gyazo.com/360f87458d251179e78691a6d46165bf.gif

## コメント
自分で海に行ってサービスを使っていて、こういった機能が欲しいという自身から出る要望の実装は本当にやりがいがあると感じました。

## 参考資料

特になし
