### PR TITLE
通知ページのN+1問題解消

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -1,6 +1,6 @@
 class NoticesController < ApplicationController
   def index
-    @notices = current_user.passive_notices.includes({ board: :user }, :board).page(params[:page])
+    @notices = current_user.passive_notices.eager_load(board: :user).page(params[:page])
     @notices.where(checked: false).each do |notice|
       notice.update(checked: true)
     end


### PR DESCRIPTION
## 概要
close #115

## 追加した機能
解決前
![image](https://user-images.githubusercontent.com/75526672/149710586-bc5e5998-c4e6-468e-8df2-9fb9b8de16c3.png)


解消後
![image](https://user-images.githubusercontent.com/75526672/149710462-433511b7-3d6a-472f-8853-eccc2f228364.png)

## コメント
`includes`では解決できなかったので`eager_load` で解決しました。
`includes` は条件によって挙動が `eager_load`か `preload` に変わります。

- includesしたテーブルでwhereによる絞り込みを行っている
- includesしたassociationに対してjoinsかreferencesも呼んでいる
- 任意のassociationに対してeager_loadも呼んでいる

> 上記のいずれかを満たす場合、eager_loadと同じ挙動(LEFT JOIN)を行い、
そうでなければpreloadと同じ挙動(クエリを分けて実行)をする。
絞り込みが必要な時に例外を投げずeager_loadにfallbackするpreload。

ここで今回の私の場合は`preload`の挙動が走っていましたが`preload`はhas_manyの場合に有用ですが
belongs_toのときでは親の数だけクエリが走ってしまうので指定したassociationをLEFT OUTER JOINで引いてキャッシュする`eager_load`の方が適しています。
noticeモデルからboard: :userへはbelongs_toの関係なので`eager_load` で定義する事で今回のN+1問題は解決しました。
SQLの学習をもっとするべきだと実感しました。

## 参考資料
[ActiveRecordのincludes, preload, eager_load の個人的な使い分け](https://moneyforward.com/engineers_blog/2019/04/02/activerecord-includes-preload-eagerload/)
[ActiveRecordのjoinsとpreloadとincludesとeager_loadの違い](https://qiita.com/k0kubun/items/80c5a5494f53bb88dc58)
[RailsのN+1対策ガイド](https://zenn.dev/yokoto/articles/e1ce604c8076b7)
